### PR TITLE
Support Hiccup syntax sugar for multiple classes

### DIFF
--- a/src/clojure/freactive/dom.cljs
+++ b/src/clojure/freactive/dom.cljs
@@ -291,7 +291,7 @@
                nil (.createElement js/document tag)
                (assert false (str "Don't know how to handle tag ns " tag-ns)))]
     (when id (set! (.-id node) id))
-    (when class (set! (.-className node) class))
+    (when class (set! (.-className node) (.replace class "." " ")))
     node))
 
 ;; ## Core DOM Manipulation Methods


### PR DESCRIPTION
Hiccup lets you write `[:div.foo.bar]` to denote `<div class="foo bar"></div>`. This patch adds support for this shorthand, taken directly from [the Hiccup compiler](https://github.com/weavejester/hiccup/blob/master/src/hiccup/compiler.clj#L62).
