### PR TITLE
Changed `rx-debug` to `debug-rx` as it's actually called.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ It should be noted that the `items-view` will be orthogonal to the other functio
 
 Reactive expressions can be hard to debug - sometimes we notice that something should be getting invalidated that isn't or it seems like something is getting updated too often.
 
-The `rx-debug` macro can be placed around the initialization of any `rx`:
+The `debug-rx` macro can be placed around the initialization of any `rx`:
 ```clojure
- (rx-debug (rx (str @n)))
+ (debug-rx (rx (str @n)))
 ```
 
 and you should seeing verbose debug statements corresponding to:


### PR DESCRIPTION
Maybe it should be the other way around? I'm also wondering if rather than having `debug-rx` be a wrapper around a call to `rx`, it should rather act like `rx` does but also output debug-info to the console? It's a small change but I think adding `-debug` at the end of `rx` to turn on debugging would be easier than adding a separate wrapper around it.
