### PR TITLE
Make sure more than two chained classes are translated.

### DIFF
--- a/src/clojure/freactive/dom.cljs
+++ b/src/clojure/freactive/dom.cljs
@@ -520,7 +520,7 @@
                  (.createElementNS js/document resolved-ns tag))
                (.createElement js/document tag))]
     (when id (set! (.-id node) id))
-    (when class (set! (.-className node) (.replace class "." " ")))
+    (when class (set! (.-className node) (clojure.string/replace class "." " ")))
     node))
 
 ;(defn- create-dom-node-simple [tag]


### PR DESCRIPTION
The interop .replace will only replace the first instance of
needle. Using clojure.string/replace will swap out all instances of
needle and thus allow more than two chained classes.
