### PR TITLE
Fix bug in ReactiveExpression.remove-watches (watchers -> watches)

### DIFF
--- a/src-cljs/freactive/core.cljs
+++ b/src-cljs/freactive/core.cljs
@@ -283,7 +283,7 @@
       (set! (.-watches this) (assoc watches key f)))
     this)
   (-remove-watch [this key]
-    (when (contains? watchers key)
+    (when (contains? watches key)
       (set! (.-watchers this) (dec watchers))
       (set! (.-watches this) (dissoc watches key)))
     this)


### PR DESCRIPTION
The `contains?` test for the specified key in ReactiveExpression.remove-watch needs to refer to the `watches` collection instead of the `watchers` count (fixes #40).
